### PR TITLE
refactor: relay management

### DIFF
--- a/solidity/contracts/AutomationVault.sol
+++ b/solidity/contracts/AutomationVault.sol
@@ -74,10 +74,13 @@ contract AutomationVault is IAutomationVault {
       // Get the length of the selectors array
       _selectorsLength = _approvedJobSelectors[_relay][_jobs[_i]].length();
 
+      // Create the array of selectors
+      bytes4[] memory _selectors;
+
       // If the job has selectors, get them
       if (_selectorsLength != 0) {
-        // Create the array of selectors
-        bytes4[] memory _selectors = new bytes4[](_selectorsLength);
+        // Set the length of the selectors array
+        _selectors = new bytes4[](_selectorsLength);
 
         // Get the list of selectors
         for (uint256 _j; _j < _selectorsLength;) {
@@ -88,13 +91,13 @@ contract AutomationVault is IAutomationVault {
             ++_j;
           }
         }
+      }
 
-        // Add the job and its selectors to the full list
-        _jobsData[_i] = IAutomationVault.JobData(_jobs[_i], _selectors);
+      // Add the job and its selectors to the full list
+      _jobsData[_i] = IAutomationVault.JobData(_jobs[_i], _selectors);
 
-        unchecked {
-          ++_i;
-        }
+      unchecked {
+        ++_i;
       }
     }
   }

--- a/solidity/interfaces/IAutomationVault.sol
+++ b/solidity/interfaces/IAutomationVault.sol
@@ -232,7 +232,7 @@ interface IAutomationVault {
 
   /**
    * @notice Add a new relay to the automation vault with the desired callers, jobs and selectors
-   * @dev   You can approve all the fields or only the necessary ones, passing the empty argument in the unwanted ones
+   * @dev    If the relay is valid, it can be passed with all the fields or only the necessary ones, passing the empty argument in the unwanted ones
    * @param  _relay The address of the relay
    * @param  _callers The array of callers
    * @param _jobsData The array of job data

--- a/solidity/interfaces/IAutomationVault.sol
+++ b/solidity/interfaces/IAutomationVault.sol
@@ -33,24 +33,17 @@ interface IAutomationVault {
   event ApproveRelay(address indexed _relay);
 
   /**
+   * @notice Emitted when a relay is deleted
+   * @param  _relay The address of the relay
+   */
+  event DeleteRelay(address indexed _relay);
+
+  /**
    * @notice Emitted when a relay caller is approved
    * @param  _relay The address of the relay
    * @param  _caller The address of the caller
    */
   event ApproveRelayCaller(address indexed _relay, address indexed _caller);
-
-  /**
-   * @notice Emitted when a relay is revoked
-   * @param  _relay The address of the relay
-   */
-  event RevokeRelay(address indexed _relay);
-
-  /**
-   * @notice Emitted when a relay caller is revoked
-   * @param  _relay The address of the relay
-   * @param  _caller The address of the caller
-   */
-  event RevokeRelayCaller(address indexed _relay, address indexed _caller);
 
   /**
    * @notice Emitted when job is approved
@@ -64,19 +57,6 @@ interface IAutomationVault {
    * @param  _functionSelector The function selector
    */
   event ApproveJobSelector(address indexed _job, bytes4 indexed _functionSelector);
-
-  /**
-   * @notice Emitted when job is revoked
-   * @param  _job The address of the job
-   */
-  event RevokeJob(address indexed _job);
-
-  /**
-   * @notice Emitted when job selector is revoked
-   * @param  _job The address of the job
-   * @param  _functionSelector The function selector
-   */
-  event RevokeJobSelector(address indexed _job, bytes4 indexed _functionSelector);
 
   /**
    * @notice Emitted when a job is executed
@@ -116,14 +96,9 @@ interface IAutomationVault {
   error AutomationVault_RelayZero();
 
   /**
-   * @notice Thrown when try to approve a relay without callers, jobs and selectors
+   * @notice Thrown when the relay is already approved
    */
-  error AutomationVault_NoCallersJobsAndSelectors();
-
-  /**
-   * @notice Thrown when the job is the zero address
-   */
-  error AutomationVault_JobZero();
+  error AutomationVault_RelayAlreadyApproved();
 
   /**
    * @notice Thrown when ether transfer fails
@@ -181,6 +156,11 @@ interface IAutomationVault {
     uint256 fee;
   }
 
+  /**
+   * @notice The data of a job
+   * @param job The address of the job
+   * @param functionSelectors The array of function selectors
+   */
   struct JobData {
     address job;
     bytes4[] functionSelectors;
@@ -225,12 +205,6 @@ interface IAutomationVault {
    */
   function relays() external view returns (address[] memory _listRelays);
 
-  /**
-   * @notice Returns the approved jobs
-   * @return _listJobs The array of approved jobs
-   */
-  function jobs() external view returns (address[] memory _listJobs);
-
   /*///////////////////////////////////////////////////////////////
                         EXTERNAL FUNCTIONS
   //////////////////////////////////////////////////////////////*/
@@ -257,31 +231,53 @@ interface IAutomationVault {
   function withdrawFunds(address _token, uint256 _amount, address _receiver) external;
 
   /**
-   * @notice Approves relay callers which will be able to call a relay to execute jobs with the specified selectors
+   * @notice Add a new relay to the automation vault with the desired callers, jobs and selectors
    * @dev   You can approve all the fields or only the necessary ones, passing the empty argument in the unwanted ones
-   * @dev   If the callers array and the selectors array are empty, the function will revert to avoid wasting gas
    * @param  _relay The address of the relay
    * @param  _callers The array of callers
    * @param _jobsData The array of job data
    */
-  function approveRelayData(
+  function addRelay(
     address _relay,
     address[] calldata _callers,
     IAutomationVault.JobData[] calldata _jobsData
   ) external;
 
   /**
-   * @notice Revokes both the desired callers to a relay and the jobs and their respective selectors
-   * @dev    You can revoke all the fields or only the necessary ones, passing the empty argument in the unwanted ones
+   * @notice Revokes the approval of a specific relay
+   * @dev    The callers, jobs and selectors will be deleted
+   * @param  _relay The address of the relay
+   */
+  function deleteRelay(address _relay) external;
+
+  /**
+   * @notice Modify the callers, jobs and selectors of a specific relay
+   * @dev    If any of the arguments is empty, the data will be deleted
    * @param  _relay The address of the relay
    * @param  _callers The array of callers
    * @param _jobsData The array of job data
    */
-  function revokeRelayData(
+  function modifyRelay(
     address _relay,
     address[] calldata _callers,
     IAutomationVault.JobData[] calldata _jobsData
   ) external;
+
+  /**
+   * @notice Modify the callers of a specific relay
+   * @dev    If the array is empty, the data will be deleted
+   * @param  _relay The address of the relay
+   * @param  _callers The array of callers
+   */
+  function modifyRelayCallers(address _relay, address[] calldata _callers) external;
+
+  /**
+   * @notice Modify the jobs and selectors of a specific relay
+   * @dev    If the array is empty, the data will be deleted, also if the function selectors array is empty
+   * @param  _relay The address of the relay
+   * @param _jobsData The array of job data
+   */
+  function modifyRelayJobs(address _relay, IAutomationVault.JobData[] calldata _jobsData) external;
 
   /**
    * @notice Executes a job and issues a payment to the fee data receivers

--- a/solidity/script/DeployNativeETH.s.sol
+++ b/solidity/script/DeployNativeETH.s.sol
@@ -40,12 +40,12 @@ abstract contract DeployNativeETH is Script {
     automationVaultFactory = new AutomationVaultFactory();
     automationVault = automationVaultFactory.deployAutomationVault(owner, _ETH, 0);
 
-    // openRelay = new OpenRelay();
-    // gelatoRelay = new GelatoRelay();
-    // keep3rRelay = new Keep3rRelay();
-    // keep3rBondedRelay = new Keep3rBondedRelay();
+    openRelay = new OpenRelay();
+    gelatoRelay = new GelatoRelay();
+    keep3rRelay = new Keep3rRelay();
+    keep3rBondedRelay = new Keep3rBondedRelay();
 
-    // xKeeperMetadata = new XKeeperMetadata();
+    xKeeperMetadata = new XKeeperMetadata();
 
     vm.stopBroadcast();
   }

--- a/solidity/script/DeployNativeETH.s.sol
+++ b/solidity/script/DeployNativeETH.s.sol
@@ -40,12 +40,12 @@ abstract contract DeployNativeETH is Script {
     automationVaultFactory = new AutomationVaultFactory();
     automationVault = automationVaultFactory.deployAutomationVault(owner, _ETH, 0);
 
-    openRelay = new OpenRelay();
-    gelatoRelay = new GelatoRelay();
-    keep3rRelay = new Keep3rRelay();
-    keep3rBondedRelay = new Keep3rBondedRelay();
+    // openRelay = new OpenRelay();
+    // gelatoRelay = new GelatoRelay();
+    // keep3rRelay = new Keep3rRelay();
+    // keep3rBondedRelay = new Keep3rBondedRelay();
 
-    xKeeperMetadata = new XKeeperMetadata();
+    // xKeeperMetadata = new XKeeperMetadata();
 
     vm.stopBroadcast();
   }

--- a/solidity/test/integration/AutomationVault.t.sol
+++ b/solidity/test/integration/AutomationVault.t.sol
@@ -22,6 +22,7 @@ contract IntegrationAutomationVault is CommonIntegrationTest {
     newOwner = makeAddr('NewOwner');
 
     vm.prank(owner);
+
     address(automationVault).call{value: 100 ether}('');
   }
 

--- a/solidity/test/integration/GelatoRelay.t.sol
+++ b/solidity/test/integration/GelatoRelay.t.sol
@@ -55,7 +55,7 @@ contract IntegrationGelatoRelay is CommonIntegrationTest {
     startHoax(owner);
 
     // AutomationVault approve relay data
-    automationVault.approveRelayData(address(gelatoRelay), _whitelistedCallers, _jobsData);
+    automationVault.addRelay(address(gelatoRelay), _whitelistedCallers, _jobsData);
 
     address(automationVault).call{value: 100 ether}('');
 

--- a/solidity/test/integration/Keep3rRelay.t.sol
+++ b/solidity/test/integration/Keep3rRelay.t.sol
@@ -63,8 +63,8 @@ contract IntegrationKeep3rRelay is CommonIntegrationTest {
     keep3rBondedRelay.setAutomationVaultRequirements(automationVault, _requirements);
 
     // AutomationVault approve relay data
-    automationVault.approveRelayData(address(keep3rRelay), _keepers, _jobsData);
-    automationVault.approveRelayData(address(keep3rBondedRelay), _keepers, _jobsData);
+    automationVault.addRelay(address(keep3rRelay), _keepers, _jobsData);
+    automationVault.addRelay(address(keep3rBondedRelay), _keepers, _jobsData);
   }
 
   function _addJobAndLiquidity(address _job, uint256 _amount) internal {

--- a/solidity/test/integration/OpenRelay.t.sol
+++ b/solidity/test/integration/OpenRelay.t.sol
@@ -26,7 +26,7 @@ contract IntegrationOpenRelay is CommonIntegrationTest {
     startHoax(owner);
 
     // AutomationVault approve relay data
-    automationVault.approveRelayData(address(openRelay), _bots, _jobsData);
+    automationVault.addRelay(address(openRelay), _bots, _jobsData);
     address(automationVault).call{value: 100 ether}('');
 
     changePrank(bot);

--- a/solidity/test/unit/AutomationVault.t.sol
+++ b/solidity/test/unit/AutomationVault.t.sol
@@ -16,18 +16,61 @@ contract AutomationVaultForTest is AutomationVault {
     pendingOwner = _pendingOwner;
   }
 
-  function addRelayEnabledCallersForTest(address _relay, address _relayCaller) public {
-    _relayCallers[_relay].add(_relayCaller);
+  function addRelayForTest(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) public {
+    for (uint256 _i; _i < _callers.length; ++_i) {
+      _relayCallers[_relay].add(_callers[_i]);
+    }
+
+    if (_job != address(0)) {
+      _relayJobs[_relay].add(_job);
+
+      for (uint256 _i; _i < _selectors.length; ++_i) {
+        _jobSelectors[_job].add(_selectors[_i]);
+      }
+    }
+
     _relays.add(_relay);
   }
 
-  function addJobEnabledSelectorsForTest(address _relay, address _job, bytes4 _functionSelector) public {
-    _relayJobSelectors[_relay][_job].add(_functionSelector);
-    _jobs.add(_job);
-  }
+  function getRelayDataForTest(address _relay)
+    public
+    view
+    returns (address[] memory _callers, IAutomationVault.JobData[] memory _jobsData)
+  {
+    // Get the list of callers
+    _callers = _relayCallers[_relay].values();
 
-  function removeJobEnabledSelectorsForTest(address _relay, address _job, bytes4 _functionSelector) public {
-    _relayJobSelectors[_relay][_job].remove(_functionSelector);
+    // Get the list of all jobs
+    address[] memory _jobs = _relayJobs[_relay].values();
+
+    // Create the array of jobs data with the jobs length
+    _jobsData = new IAutomationVault.JobData[](_jobs.length);
+
+    // Get the list of jobs and their selectors
+    for (uint256 _i; _i < _jobs.length;) {
+      // Create the array of selectors
+      bytes4[] memory _selectors = new bytes4[](_jobSelectors[_jobs[_i]].length());
+
+      // If the job has selectors, get them
+      if (_selectors.length != 0) {
+        // Get the list of selectors
+        for (uint256 _j; _j < _selectors.length;) {
+          // Convert the bytes32 selector to bytes4
+          _selectors[_j] = bytes4(_jobSelectors[_jobs[_i]].at(_j));
+
+          unchecked {
+            ++_j;
+          }
+        }
+
+        // Add the job and its selectors to the full list
+        _jobsData[_i] = IAutomationVault.JobData(_jobs[_i], _selectors);
+
+        unchecked {
+          ++_i;
+        }
+      }
+    }
   }
 }
 
@@ -40,51 +83,34 @@ abstract contract AutomationVaultUnitTest is Test {
   /// Events
   event ChangeOwner(address indexed _pendingOwner);
   event AcceptOwner(address indexed _owner);
-  event DepositFunds(address indexed _token, uint256 _amount);
   event WithdrawFunds(address indexed _token, uint256 _amount, address indexed _receiver);
   event ApproveRelay(address indexed _relay);
+  event DeleteRelay(address indexed _relay);
   event ApproveRelayCaller(address indexed _relay, address indexed _caller);
-  event RevokeRelay(address indexed _relay);
-  event RevokeRelayCaller(address indexed _relay, address indexed _caller);
   event ApproveJob(address indexed _job);
   event ApproveJobSelector(address indexed _job, bytes4 indexed _functionSelector);
-  event RevokeJob(address indexed _job);
-  event RevokeJobSelector(address indexed _job, bytes4 indexed _functionSelector);
   event JobExecuted(address indexed _relay, address indexed _relayCaller, address indexed _job, bytes _jobData);
   event IssuePayment(
     address indexed _relay, address indexed _relayCaller, address indexed _feeRecipient, address _feeToken, uint256 _fee
   );
+  event NativeTokenReceived(address indexed _sender, uint256 _amount);
 
   /// AutomationVault contract
   AutomationVaultForTest public automationVault;
 
   /// Mock contracts
   address public token;
-  address public job;
-  address public relay;
-  address public relayCaller;
 
   /// EOAs
   address public owner;
   address public pendingOwner;
   address public receiver;
 
-  /// Data
-  bytes4 public jobSelector;
-  bytes public jobData;
-
   function setUp() public virtual {
-    jobSelector = bytes4(keccak256('jobSelector()'));
-    jobData = abi.encodeWithSelector(jobSelector, owner);
-
     owner = makeAddr('Owner');
     pendingOwner = makeAddr('PendingOwner');
     receiver = makeAddr('Receiver');
-
     token = makeAddr('Token');
-    job = makeAddr('Job');
-    relay = makeAddr('Relay');
-    relayCaller = makeAddr('RelayCaller');
 
     automationVault = new AutomationVaultForTest(owner, _ETH);
   }
@@ -107,23 +133,23 @@ contract UnitGetRelayData is AutomationVaultUnitTest {
   EnumerableSet.AddressSet internal _cleanCallers;
   EnumerableSet.Bytes32Set internal _cleanSelectors;
 
-  modifier happyPath(address _relay, address[] memory _relayCallers, address _job, bytes4[] memory _functionSelectors) {
+  modifier happyPath(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) {
     vm.assume(_relay != address(0));
     vm.assume(_job != address(0));
-    vm.assume(_functionSelectors.length > 0 && _functionSelectors.length < 30);
-    vm.assume(_relayCallers.length > 0 && _relayCallers.length < 30);
+    vm.assume(_callers.length > 0 && _callers.length < 30);
+    vm.assume(_selectors.length > 0 && _selectors.length < 30);
 
     // Clean the array to avoid duplicates
-    for (uint256 _i; _i < _relayCallers.length; ++_i) {
-      automationVault.addRelayEnabledCallersForTest(_relay, _relayCallers[_i]);
-      _cleanCallers.add(_relayCallers[_i]);
+    for (uint256 _i; _i < _callers.length; ++_i) {
+      _cleanCallers.add(_callers[_i]);
     }
 
     // Clean the array to avoid duplicates
-    for (uint256 _i; _i < _functionSelectors.length; ++_i) {
-      _cleanSelectors.add(_functionSelectors[_i]);
-      automationVault.addJobEnabledSelectorsForTest(_relay, _job, _functionSelectors[_i]);
+    for (uint256 _i; _i < _selectors.length; ++_i) {
+      _cleanSelectors.add(_selectors[_i]);
     }
+
+    automationVault.addRelayForTest(_relay, _callers, _job, _selectors);
 
     vm.startPrank(owner);
 
@@ -135,17 +161,17 @@ contract UnitGetRelayData is AutomationVaultUnitTest {
 
   function testRelayData(
     address _relay,
-    address[] memory _relayCallers,
+    address[] memory _callers,
     address _job,
-    bytes4[] memory _functionSelector
-  ) public happyPath(_relay, _relayCallers, _job, _functionSelector) {
-    (address[] memory _callers, IAutomationVault.JobData[] memory _jobsData) = automationVault.getRelayData(_relay);
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _callers, _job, _selectors) {
+    (address[] memory _relayCallers, IAutomationVault.JobData[] memory _jobsData) = automationVault.getRelayData(_relay);
 
     // Check the relay callers
-    assertEq(_callers.length, _cleanCallers.length());
+    assertEq(_relayCallers.length, _cleanCallers.length());
 
-    for (uint256 _i; _i < _callers.length; ++_i) {
-      assertEq(_callers[_i], _cleanCallers.at(_i));
+    for (uint256 _i; _i < _relayCallers.length; ++_i) {
+      assertEq(_relayCallers[_i], _cleanCallers.at(_i));
     }
 
     // Check the jobs
@@ -164,21 +190,11 @@ contract UnitAutomationVaultListRelays is AutomationVaultUnitTest {
   /**
    * @notice Check that the relays length is correct
    */
-  function testRelaysLength(address _relay) public {
-    automationVault.addRelayEnabledCallersForTest(_relay, owner);
+  function testRelaysLength(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) public {
+    automationVault.addRelayForTest(_relay, _callers, _job, _selectors);
 
     assertEq(automationVault.relays().length, 1);
-  }
-}
-
-contract UnitAutomationVaultListJobs is AutomationVaultUnitTest {
-  /**
-   * @notice Check that the jobs length is correct
-   */
-  function testJobLength(address _relay, address _job) public {
-    automationVault.addJobEnabledSelectorsForTest(_relay, _job, jobSelector);
-
-    assertEq(automationVault.jobs().length, 1);
+    assertEq(automationVault.relays()[0], _relay);
   }
 }
 
@@ -349,26 +365,29 @@ contract UnitAutomationVaultWithdrawFunds is AutomationVaultUnitTest {
 /**
  * @dev Is not possible to create in the happy path type struct IAutomationVault.JobData memory[] memory to storage because is not yet supported.
  */
-contract UnitAutomationVaultApproveRelayData is AutomationVaultUnitTest {
-  address[] internal _callers;
-  bytes4[] internal _functionSelectors;
+contract UnitAutomationVaultAddRelayData is AutomationVaultUnitTest {
+  using EnumerableSet for EnumerableSet.AddressSet;
+  using EnumerableSet for EnumerableSet.Bytes32Set;
 
-  modifier happyPath(address _relay, address _job, bytes4 _functionSelector) {
+  EnumerableSet.AddressSet internal _cleanCallers;
+  EnumerableSet.Bytes32Set internal _cleanSelectors;
+
+  modifier happyPath(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) {
     /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
     vm.assume(_relay != address(0));
     vm.assume(_job != address(0));
-    vm.assume(_functionSelector != jobSelector);
+    vm.assume(_callers.length > 0 && _callers.length < 30);
+    vm.assume(_selectors.length > 0 && _selectors.length < 30);
 
-    /// Create the data
-    _callers = new address[](2);
+    // Clean the array to avoid duplicates
+    for (uint256 _i; _i < _callers.length; ++_i) {
+      _cleanCallers.add(_callers[_i]);
+    }
 
-    _callers[0] = (owner);
-    _callers[1] = (pendingOwner);
-
-    _functionSelectors = new bytes4[](2);
-
-    _functionSelectors[0] = jobSelector;
-    _functionSelectors[1] = _functionSelector;
+    // Clean the array to avoid duplicates
+    for (uint256 _i; _i < _selectors.length; ++_i) {
+      _cleanSelectors.add(_selectors[_i]);
+    }
 
     vm.startPrank(owner);
     _;
@@ -377,31 +396,35 @@ contract UnitAutomationVaultApproveRelayData is AutomationVaultUnitTest {
   /**
    * @notice Checks that the test has to revert if the caller is not the owner
    */
-  function testRevertIfCallerIsNotOwner(address _relay, IAutomationVault.JobData[] memory _jobsData) public {
+  function testRevertIfCallerIsNotOwner(address _relay) public {
     vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_OnlyOwner.selector));
 
     vm.prank(pendingOwner);
-    automationVault.approveRelayData(_relay, _callers, _jobsData);
+    automationVault.addRelay(_relay, new address[](0), new IAutomationVault.JobData[](0));
   }
 
   /**
    * @notice Checks that the test has to revert if the relay address is zero
    */
-  function testRevertIfRelayIsZero(IAutomationVault.JobData[] memory _jobsData) public {
+  function testRevertIfRelayIsZero() public {
     vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_RelayZero.selector));
 
     vm.prank(owner);
-    automationVault.approveRelayData(address(0), _callers, _jobsData);
+    automationVault.addRelay(address(0), new address[](0), new IAutomationVault.JobData[](0));
   }
 
   /**
-   * @notice Checks that the test has to revert if the callers, jobs and selectors length is zero
+   * @notice Checks that revert if the relay is already approved
    */
-  function testRevertIfNoCallersJobsAndSelectors() public {
-    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_NoCallersJobsAndSelectors.selector));
 
+  function testRevertIfRelayAlreadyApproved(address _relay) public {
+    vm.assume(_relay != address(0));
+
+    automationVault.addRelayForTest(_relay, new address[](0), address(0), new bytes4[](0));
+
+    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_RelayAlreadyApproved.selector));
     vm.prank(owner);
-    automationVault.approveRelayData(relay, new address[](0), new IAutomationVault.JobData[](0));
+    automationVault.addRelay(_relay, new address[](0), new IAutomationVault.JobData[](0));
   }
 
   /**
@@ -409,17 +432,18 @@ contract UnitAutomationVaultApproveRelayData is AutomationVaultUnitTest {
    */
   function testEmitApproveRelay(
     address _relay,
+    address[] memory _callers,
     address _job,
-    bytes4 _functionSelector
-  ) public happyPath(_relay, _job, _functionSelector) {
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _callers, _job, _selectors) {
     IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
     _jobsData[0].job = _job;
-    _jobsData[0].functionSelectors = _functionSelectors;
+    _jobsData[0].functionSelectors = _selectors;
 
     vm.expectEmit();
     emit ApproveRelay(_relay);
 
-    automationVault.approveRelayData(_relay, _callers, _jobsData);
+    automationVault.addRelay(_relay, _callers, _jobsData);
   }
 
   /**
@@ -427,19 +451,291 @@ contract UnitAutomationVaultApproveRelayData is AutomationVaultUnitTest {
    */
   function testEmitApproveCaller(
     address _relay,
+    address[] memory _callers,
     address _job,
-    bytes4 _functionSelector
-  ) public happyPath(_relay, _job, _functionSelector) {
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _callers, _job, _selectors) {
     IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
     _jobsData[0].job = _job;
-    _jobsData[0].functionSelectors = _functionSelectors;
+    _jobsData[0].functionSelectors = _selectors;
 
-    for (uint256 _i; _i < _callers.length; _i++) {
+    for (uint256 _i; _i < _cleanCallers.length(); _i++) {
       vm.expectEmit();
-      emit ApproveRelayCaller(_relay, _callers[_i]);
+      emit ApproveRelayCaller(_relay, _cleanCallers.at(_i));
     }
 
-    automationVault.approveRelayData(_relay, _callers, _jobsData);
+    automationVault.addRelay(_relay, _callers, _jobsData);
+  }
+
+  /**
+   * @notice Emit ApproveJob event when the job is approved
+   */
+  function testEmitApproveJob(
+    address _relay,
+    address[] memory _callers,
+    address _job,
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _callers, _job, _selectors) {
+    IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
+    _jobsData[0].job = _job;
+    _jobsData[0].functionSelectors = _selectors;
+
+    vm.expectEmit();
+    emit ApproveJob(_job);
+
+    automationVault.addRelay(_relay, _callers, _jobsData);
+  }
+
+  /**
+   * @notice Emit ApproveJobSelector event when the job selector is approved
+   */
+  function testEmitApproveFunctionSelector(
+    address _relay,
+    address[] memory _callers,
+    address _job,
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _callers, _job, _selectors) {
+    IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
+    _jobsData[0].job = _job;
+    _jobsData[0].functionSelectors = _selectors;
+
+    for (uint256 _i; _i < _cleanSelectors.length(); _i++) {
+      vm.expectEmit();
+      emit ApproveJobSelector(_job, bytes4(_cleanSelectors.at(_i)));
+    }
+
+    automationVault.addRelay(_relay, _callers, _jobsData);
+  }
+}
+
+/**
+ * @dev Is not possible to create in the happy path type struct IAutomationVault.JobData memory[] memory to storage because is not yet supported.
+ */
+contract UnitAutomationVaultDeleteRelay is AutomationVaultUnitTest {
+  modifier happyPath(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) {
+    /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
+    vm.assume(_relay != address(0));
+    vm.assume(_job != address(0));
+    vm.assume(_callers.length > 0 && _callers.length < 30);
+    vm.assume(_selectors.length > 0 && _selectors.length < 30);
+
+    automationVault.addRelayForTest(_relay, _callers, _job, _selectors);
+
+    vm.startPrank(owner);
+    _;
+  }
+
+  /**
+   * @notice Checks that the test has to revert if the caller is not the owner
+   */
+  function testRevertIfCallerIsNotOwner(address _relay) public {
+    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_OnlyOwner.selector));
+
+    vm.prank(pendingOwner);
+    automationVault.deleteRelay(_relay);
+  }
+
+  /**
+   * @notice Checks that the test has to revert if the relay address is zero
+   */
+  function testRevertIfRelayIsZero(address _relay) public {
+    vm.assume(_relay == address(0));
+    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_RelayZero.selector));
+
+    vm.prank(owner);
+    automationVault.deleteRelay(_relay);
+  }
+
+  /**
+   * @notice Checks that mappings associated with the relay are deleted
+   */
+  function testMappingsAreDeleted(
+    address _relay,
+    address[] memory _callers,
+    address _job,
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _callers, _job, _selectors) {
+    automationVault.deleteRelay(_relay);
+
+    (address[] memory _relayCallers, IAutomationVault.JobData[] memory _jobData) =
+      automationVault.getRelayDataForTest(_relay);
+
+    assertEq(automationVault.relays().length, 0);
+    assertEq(_relayCallers.length, 0);
+    assertEq(_jobData.length, 0);
+  }
+
+  /**
+   * @notice Emit DeleteRelay event when the relay is deleted
+   */
+  function testEmitDeleteRelay(
+    address _relay,
+    address[] memory _callers,
+    address _job,
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _callers, _job, _selectors) {
+    vm.expectEmit();
+    emit DeleteRelay(_relay);
+
+    automationVault.deleteRelay(_relay);
+  }
+}
+
+/**
+ * @dev Is not possible to create in the happy path type struct IAutomationVault.JobData memory[] memory to storage because is not yet supported.
+ */
+contract UnitAutomationVaultModifyRelayCallers is AutomationVaultUnitTest {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  EnumerableSet.AddressSet internal _cleanCallers;
+
+  modifier happyPath(address _relay, address[] memory _callers) {
+    /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
+    vm.assume(_relay != address(0));
+    vm.assume(_callers.length > 0 && _callers.length < 30);
+
+    automationVault.addRelayForTest(_relay, new address[](0), address(0), new bytes4[](0));
+
+    for (uint256 _i; _i < _callers.length; ++_i) {
+      _cleanCallers.add(_callers[_i]);
+    }
+
+    vm.startPrank(owner);
+    _;
+  }
+
+  /**
+   * @notice Checks that the test has to revert if the caller is not the owner
+   */
+  function testRevertIfCallerIsNotOwner(address _relay, address[] memory _callers) public {
+    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_OnlyOwner.selector));
+
+    vm.prank(pendingOwner);
+    automationVault.modifyRelayCallers(_relay, _callers);
+  }
+
+  /**
+   * @notice Checks that the test has to revert if the relay address is zero
+   */
+  function testRevertIfRelayIsZero(address _relay, address[] memory _callers) public {
+    vm.assume(_relay == address(0));
+    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_RelayZero.selector));
+
+    vm.prank(owner);
+    automationVault.modifyRelayCallers(_relay, _callers);
+  }
+
+  /**
+   * @notice Checks that callers are modified correctly
+   */
+  function testRelayCallersAreModified(address _relay, address[] memory _callers) public happyPath(_relay, _callers) {
+    // Get the list of callers
+    (address[] memory _relayCallers,) = automationVault.getRelayDataForTest(_relay);
+
+    // Length should be zero
+    assertEq(_relayCallers.length, 0);
+
+    // Modify the callers
+    automationVault.modifyRelayCallers(_relay, _callers);
+
+    // Get the list of callers
+    (_relayCallers,) = automationVault.getRelayDataForTest(_relay);
+
+    for (uint256 _i; _i < _relayCallers.length; ++_i) {
+      assertEq(_relayCallers[_i], _cleanCallers.at(_i));
+    }
+  }
+
+  /**
+   * @notice Emit ApproveRelayCaller event when the relay caller is approved
+   */
+  function testEmitApproveRelayCaller(address _relay, address[] memory _callers) public happyPath(_relay, _callers) {
+    for (uint256 _i; _i < _cleanCallers.length(); ++_i) {
+      vm.expectEmit();
+      emit ApproveRelayCaller(_relay, _cleanCallers.at(_i));
+    }
+
+    automationVault.modifyRelayCallers(_relay, _callers);
+  }
+}
+
+/**
+ * @dev Is not possible to create in the happy path type struct IAutomationVault.JobData memory[] memory to storage because is not yet supported.
+ */
+contract UnitAutomationVaultModifyRelayJobs is AutomationVaultUnitTest {
+  using EnumerableSet for EnumerableSet.Bytes32Set;
+
+  EnumerableSet.Bytes32Set internal _cleanSelectors;
+
+  modifier happyPath(address _relay, address _job, bytes4[] memory _selectors) {
+    /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
+    vm.assume(_relay != address(0));
+    vm.assume(_job != address(0));
+    vm.assume(_selectors.length > 0 && _selectors.length < 30);
+
+    automationVault.addRelayForTest(_relay, new address[](0), address(0), new bytes4[](0));
+
+    for (uint256 _i; _i < _selectors.length; ++_i) {
+      _cleanSelectors.add(_selectors[_i]);
+    }
+
+    vm.startPrank(owner);
+    _;
+  }
+
+  /**
+   * @notice Checks that the test has to revert if the caller is not the owner
+   */
+  function testRevertIfCallerIsNotOwner(address _relay) public {
+    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_OnlyOwner.selector));
+
+    vm.prank(pendingOwner);
+    automationVault.modifyRelayJobs(_relay, new IAutomationVault.JobData[](0));
+  }
+
+  /**
+   * @notice Checks that the test has to revert if the relay address is zero
+   */
+  function testRevertIfRelayIsZero(address _relay) public {
+    vm.assume(_relay == address(0));
+    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_RelayZero.selector));
+
+    vm.prank(owner);
+    automationVault.modifyRelayJobs(_relay, new IAutomationVault.JobData[](0));
+  }
+
+  /**
+   * @notice Checks that callers are modified correctly
+   */
+  function testRelayCallersAreModified(
+    address _relay,
+    address _job,
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _job, _selectors) {
+    // Get the list of callers
+    (, IAutomationVault.JobData[] memory _jobsData) = automationVault.getRelayDataForTest(_relay);
+
+    // Length should be zero
+    assertEq(_jobsData.length, 0);
+
+    _jobsData = new IAutomationVault.JobData[](1);
+    _jobsData[0].job = _job;
+    _jobsData[0].functionSelectors = _selectors;
+
+    // Modify the callers
+    automationVault.modifyRelayJobs(_relay, _jobsData);
+
+    // Get the list of callers
+    (, _jobsData) = automationVault.getRelayDataForTest(_relay);
+
+    for (uint256 _i; _i < _jobsData.length; ++_i) {
+      assertEq(_jobsData[_i].job, _job);
+      assertEq(_jobsData[_i].functionSelectors.length, _cleanSelectors.length());
+
+      for (uint256 _j; _j < _jobsData[_i].functionSelectors.length; ++_j) {
+        assertEq(_jobsData[_i].functionSelectors[_j], _cleanSelectors.at(_j));
+      }
+    }
   }
 
   /**
@@ -448,16 +744,16 @@ contract UnitAutomationVaultApproveRelayData is AutomationVaultUnitTest {
   function testEmitApproveJob(
     address _relay,
     address _job,
-    bytes4 _functionSelector
-  ) public happyPath(_relay, _job, _functionSelector) {
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _job, _selectors) {
     IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
     _jobsData[0].job = _job;
-    _jobsData[0].functionSelectors = _functionSelectors;
+    _jobsData[0].functionSelectors = _selectors;
 
     vm.expectEmit();
     emit ApproveJob(_job);
 
-    automationVault.approveRelayData(_relay, _callers, _jobsData);
+    automationVault.modifyRelayJobs(_relay, _jobsData);
   }
 
   /**
@@ -466,360 +762,228 @@ contract UnitAutomationVaultApproveRelayData is AutomationVaultUnitTest {
   function testEmitApproveFunctionSelector(
     address _relay,
     address _job,
-    bytes4 _functionSelector
-  ) public happyPath(_relay, _job, _functionSelector) {
+    bytes4[] memory _selectors
+  ) public happyPath(_relay, _job, _selectors) {
     IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
     _jobsData[0].job = _job;
-    _jobsData[0].functionSelectors = _functionSelectors;
+    _jobsData[0].functionSelectors = _selectors;
 
-    for (uint256 _i; _i < _functionSelectors.length; _i++) {
+    for (uint256 _i; _i < _cleanSelectors.length(); ++_i) {
       vm.expectEmit();
-      emit ApproveJobSelector(_job, _functionSelectors[_i]);
+      emit ApproveJobSelector(_job, bytes4(_cleanSelectors.at(_i)));
     }
 
-    automationVault.approveRelayData(_relay, _callers, _jobsData);
+    automationVault.modifyRelayJobs(_relay, _jobsData);
   }
 }
 
-/**
- * @dev Is not possible to create in the happy path type struct IAutomationVault.JobData memory[] memory to storage because is not yet supported.
- */
-contract UnitAutomationVaultRevokeRelayData is AutomationVaultUnitTest {
-  address[] internal _callers;
-  bytes4[] internal _functionSelectors;
+// contract UnitAutomationVaultExec is AutomationVaultUnitTest {
+//   modifier happyPath(IAutomationVault.ExecData[] memory _execData, IAutomationVault.FeeData[] memory _feeData) {
+//     vm.assume(_execData.length < 30 && _feeData.length < 30);
 
-  modifier happyPath(address _relay, address _job, bytes4 _functionSelector) {
-    /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
-    vm.assume(_relay != address(0));
-    vm.assume(_job != address(0));
-    vm.assume(_functionSelector != jobSelector);
+//     automationVault.addRelayEnabledCallersForTest(relay, relayCaller);
 
-    /// Create the data
-    _callers = new address[](2);
+//     for (uint256 _i; _i < _execData.length; ++_i) {
+//       automationVault.addJobEnabledSelectorsForTest(relay, _execData[_i].job, bytes4(_execData[_i].jobData));
+//       assumeNoPrecompiles(_execData[_i].job);
+//       vm.assume(_execData[_i].job != address(vm));
+//       vm.mockCall(_execData[_i].job, abi.encodeWithSelector(bytes4(_execData[_i].jobData)), abi.encode());
+//     }
 
-    _callers[0] = (owner);
-    _callers[1] = (pendingOwner);
+//     for (uint256 _i; _i < _feeData.length; ++_i) {
+//       assumeNoPrecompiles(_feeData[_i].feeRecipient);
+//       assumePayable(_feeData[_i].feeRecipient);
+//       assumeNoPrecompiles(_feeData[_i].feeToken);
+//       vm.assume(_feeData[_i].feeToken != address(vm));
+//       vm.mockCall(_feeData[_i].feeToken, abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
+//     }
 
-    _functionSelectors = new bytes4[](2);
+//     deal(address(automationVault), type(uint256).max);
 
-    _functionSelectors[0] = jobSelector;
-    _functionSelectors[1] = _functionSelector;
+//     vm.startPrank(relay);
+//     _;
+//   }
 
-    automationVault.addRelayEnabledCallersForTest(_relay, owner);
-    automationVault.addRelayEnabledCallersForTest(_relay, pendingOwner);
+//   /**
+//    * @notice Checks that the test has to revert if the caller is not the relay caller
+//    */
+//   function testRevertIfNotApprovedRelayCaller(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData
+//   ) public happyPath(_execData, _feeData) {
+//     vm.expectRevert(IAutomationVault.AutomationVault_NotApprovedRelayCaller.selector);
 
-    automationVault.addJobEnabledSelectorsForTest(_relay, _job, jobSelector);
-    automationVault.addJobEnabledSelectorsForTest(_relay, _job, _functionSelector);
+//     changePrank(owner);
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }
 
-    vm.startPrank(owner);
-    _;
-  }
+//   function testRevertIfNotApprovedJobSelector(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_execData.length > 3);
+//     automationVault.removeJobEnabledSelectorsForTest(relay, _execData[1].job, bytes4(_execData[1].jobData));
 
-  /**
-   * @notice Checks that the test has to revert if the caller is not the owner
-   */
-  function testRevertIfCallerIsNotOwner(address _relay, IAutomationVault.JobData[] memory _jobsData) public {
-    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_OnlyOwner.selector));
+//     vm.expectRevert(IAutomationVault.AutomationVault_NotApprovedJobSelector.selector);
 
-    vm.prank(pendingOwner);
-    automationVault.revokeRelayData(_relay, _callers, _jobsData);
-  }
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }
 
-  /**
-   * @notice Checks that the test has to revert if the relay address is zero
-   */
-  function testRevertIfRelayIsZero(IAutomationVault.JobData[] memory _jobsData) public {
-    vm.expectRevert(abi.encodeWithSelector(IAutomationVault.AutomationVault_RelayZero.selector));
+//   /**
+//    * @notice Checks that the test has to revert if the job call failed
+//    */
+//   function testRevertIfJobCallFailed(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_execData.length > 3);
+//     vm.etch(_execData[1].job, type(NoFallbackForTest).runtimeCode);
+//     vm.mockCallRevert(_execData[1].job, abi.encodeWithSelector(bytes4(_execData[1].jobData)), abi.encode());
 
-    vm.prank(owner);
-    automationVault.revokeRelayData(address(0), _callers, _jobsData);
-  }
+//     vm.expectRevert(IAutomationVault.AutomationVault_ExecFailed.selector);
 
-  /**
-   * @notice Emit RevokeRelay event when the relay is revoked
-   */
-  function testEmitRevokeRelay(
-    address _relay,
-    address _job,
-    bytes4 _functionSelector
-  ) public happyPath(_relay, _job, _functionSelector) {
-    IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
-    _jobsData[0].job = _job;
-    _jobsData[0].functionSelectors = _functionSelectors;
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }
 
-    vm.expectEmit();
-    emit RevokeRelay(_relay);
+//   /**
+//    * @notice Checks that call is executed correctly without fees
+//    */
+//   function testCallOnlyJobFunction(IAutomationVault.ExecData[] memory _execData)
+//     public
+//     happyPath(_execData, new IAutomationVault.FeeData[](0))
+//   {
+//     vm.assume(_execData.length > 3);
+//     IAutomationVault.FeeData[] memory _feeData = new IAutomationVault.FeeData[](0);
 
-    automationVault.revokeRelayData(_relay, _callers, _jobsData);
-  }
+//     for (uint256 _i; _i < _execData.length; ++_i) {
+//       vm.expectCall(_execData[_i].job, _execData[_i].jobData, 1);
+//     }
 
-  /**
-   * @notice Emit RevokeRelayCaller event when the relay caller is revoked
-   */
-  function testEmitRevokeCaller(
-    address _relay,
-    address _job,
-    bytes4 _functionSelector
-  ) public happyPath(_relay, _job, _functionSelector) {
-    IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
-    _jobsData[0].job = _job;
-    _jobsData[0].functionSelectors = _functionSelectors;
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }
 
-    for (uint256 _i; _i < _callers.length; _i++) {
-      vm.expectEmit();
-      emit RevokeRelayCaller(_relay, _callers[_i]);
-    }
+//   /**
+//    * @notice Checks that call is executed correctly with fees
+//    */
+//   function testCallJobFunction(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_execData.length > 3);
 
-    automationVault.revokeRelayData(_relay, _callers, _jobsData);
-  }
+//     for (uint256 _i; _i < _execData.length; ++_i) {
+//       vm.expectCall(_execData[_i].job, _execData[_i].jobData, 1);
+//     }
 
-  /**
-   * @notice Emit RevokeJob event when the job is revoked
-   */
-  function testEmitRevokeJob(
-    address _relay,
-    address _job,
-    bytes4 _functionSelector
-  ) public happyPath(_relay, _job, _functionSelector) {
-    IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
-    _jobsData[0].job = _job;
-    _jobsData[0].functionSelectors = _functionSelectors;
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }
 
-    vm.expectEmit();
-    emit RevokeJob(_job);
+//   /**
+//    * @notice Checks that call is executed correctly with fees and open sender
+//    */
+//   function testCallJobFunctionWithOpenSender(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData,
+//     address _sender
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_execData.length > 3);
+//     automationVault.addRelayEnabledCallersForTest(relay, _ALL);
 
-    automationVault.revokeRelayData(_relay, _callers, _jobsData);
-  }
+//     for (uint256 _i; _i < _execData.length; ++_i) {
+//       vm.expectCall(_execData[_i].job, _execData[_i].jobData, 1);
+//     }
 
-  /**
-   * @notice Emit RevokeJobSelector event when the job selector is revoked
-   */
-  function testEmitRevokeFunctionSelector(
-    address _relay,
-    address _job,
-    bytes4 _functionSelector
-  ) public happyPath(_relay, _job, _functionSelector) {
-    IAutomationVault.JobData[] memory _jobsData = new IAutomationVault.JobData[](1);
-    _jobsData[0].job = _job;
-    _jobsData[0].functionSelectors = _functionSelectors;
+//     automationVault.exec(_sender, _execData, _feeData);
+//   }
 
-    for (uint256 _i; _i < _functionSelectors.length; _i++) {
-      vm.expectEmit();
-      emit RevokeJobSelector(_job, _functionSelectors[_i]);
-    }
+//   /**
+//    * @notice Emit JobExecuted event when the job is executed
+//    */
+//   function testEmitJobExecuted(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_execData.length > 3);
 
-    automationVault.revokeRelayData(_relay, _callers, _jobsData);
-  }
-}
+//     for (uint256 _i; _i < _execData.length; ++_i) {
+//       vm.expectEmit();
+//       emit JobExecuted(relay, relayCaller, _execData[_i].job, _execData[_i].jobData);
+//     }
 
-contract UnitAutomationVaultExec is AutomationVaultUnitTest {
-  modifier happyPath(IAutomationVault.ExecData[] memory _execData, IAutomationVault.FeeData[] memory _feeData) {
-    vm.assume(_execData.length < 30 && _feeData.length < 30);
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }
 
-    automationVault.addRelayEnabledCallersForTest(relay, relayCaller);
+//   /**
+//    * @notice Checks that the test has to revert if the native token transfer failed
+//    */
+//   function testRevertIfNativeTokenTransferFailed(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_feeData.length > 3);
+//     _feeData[1].feeToken = _ETH;
+//     vm.etch(_feeData[1].feeRecipient, type(NoFallbackForTest).runtimeCode);
 
-    for (uint256 _i; _i < _execData.length; ++_i) {
-      automationVault.addJobEnabledSelectorsForTest(relay, _execData[_i].job, bytes4(_execData[_i].jobData));
-      assumeNoPrecompiles(_execData[_i].job);
-      vm.assume(_execData[_i].job != address(vm));
-      vm.mockCall(_execData[_i].job, abi.encodeWithSelector(bytes4(_execData[_i].jobData)), abi.encode());
-    }
+//     vm.expectRevert(IAutomationVault.AutomationVault_NativeTokenTransferFailed.selector);
 
-    for (uint256 _i; _i < _feeData.length; ++_i) {
-      assumeNoPrecompiles(_feeData[_i].feeRecipient);
-      assumePayable(_feeData[_i].feeRecipient);
-      assumeNoPrecompiles(_feeData[_i].feeToken);
-      vm.assume(_feeData[_i].feeToken != address(vm));
-      vm.mockCall(_feeData[_i].feeToken, abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
-    }
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }
 
-    deal(address(automationVault), type(uint256).max);
+//   /**
+//    * @notice Checks that native token transfer is executed correctly
+//    */
+//   function testCallNativeTokenTransfer(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData,
+//     uint128 _fee
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_feeData.length > 3);
+//     for (uint256 _i; _i < _feeData.length; ++_i) {
+//       _feeData[_i].feeToken = _ETH;
+//       _feeData[_i].fee = _fee;
+//     }
 
-    vm.startPrank(relay);
-    _;
-  }
+//     automationVault.exec(relayCaller, _execData, _feeData);
 
-  /**
-   * @notice Checks that the test has to revert if the caller is not the relay caller
-   */
-  function testRevertIfNotApprovedRelayCaller(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_execData, _feeData) {
-    vm.expectRevert(IAutomationVault.AutomationVault_NotApprovedRelayCaller.selector);
+//     for (uint256 _i; _i < _feeData.length; ++_i) {
+//       assertGe(_feeData[_i].feeRecipient.balance, _feeData[_i].fee);
+//     }
+//   }
 
-    changePrank(owner);
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
+//   /**
+//    * @notice Checks that token transfer is executed correctly
+//    */
+//   function testCallTokenTransfer(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_feeData.length > 3);
+//     for (uint256 _i; _i < _feeData.length; ++_i) {
+//       vm.assume(_feeData[_i].feeToken != _ETH);
+//     }
 
-  function testRevertIfNotApprovedJobSelector(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_execData.length > 3);
-    automationVault.removeJobEnabledSelectorsForTest(relay, _execData[1].job, bytes4(_execData[1].jobData));
+//     for (uint256 _i; _i < _feeData.length; ++_i) {
+//       vm.expectCall(
+//         _feeData[_i].feeToken, abi.encodeCall(IERC20.transfer, (_feeData[_i].feeRecipient, _feeData[_i].fee)), 1
+//       );
+//     }
 
-    vm.expectRevert(IAutomationVault.AutomationVault_NotApprovedJobSelector.selector);
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }
 
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
+//   /**
+//    * @notice Emit IssuePayment event when the payment is issued
+//    */
+//   function testEmitIssuePayment(
+//     IAutomationVault.ExecData[] memory _execData,
+//     IAutomationVault.FeeData[] memory _feeData
+//   ) public happyPath(_execData, _feeData) {
+//     vm.assume(_feeData.length > 3);
 
-  /**
-   * @notice Checks that the test has to revert if the job call failed
-   */
-  function testRevertIfJobCallFailed(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_execData.length > 3);
-    vm.etch(_execData[1].job, type(NoFallbackForTest).runtimeCode);
-    vm.mockCallRevert(_execData[1].job, abi.encodeWithSelector(bytes4(_execData[1].jobData)), abi.encode());
+//     for (uint256 _i; _i < _feeData.length; ++_i) {
+//       vm.expectEmit();
+//       emit IssuePayment(relay, relayCaller, _feeData[_i].feeRecipient, _feeData[_i].feeToken, _feeData[_i].fee);
+//     }
 
-    vm.expectRevert(IAutomationVault.AutomationVault_ExecFailed.selector);
-
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
-
-  /**
-   * @notice Checks that call is executed correctly without fees
-   */
-  function testCallOnlyJobFunction(IAutomationVault.ExecData[] memory _execData)
-    public
-    happyPath(_execData, new IAutomationVault.FeeData[](0))
-  {
-    vm.assume(_execData.length > 3);
-    IAutomationVault.FeeData[] memory _feeData = new IAutomationVault.FeeData[](0);
-
-    for (uint256 _i; _i < _execData.length; ++_i) {
-      vm.expectCall(_execData[_i].job, _execData[_i].jobData, 1);
-    }
-
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
-
-  /**
-   * @notice Checks that call is executed correctly with fees
-   */
-  function testCallJobFunction(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_execData.length > 3);
-
-    for (uint256 _i; _i < _execData.length; ++_i) {
-      vm.expectCall(_execData[_i].job, _execData[_i].jobData, 1);
-    }
-
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
-
-  /**
-   * @notice Checks that call is executed correctly with fees and open sender
-   */
-  function testCallJobFunctionWithOpenSender(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData,
-    address _sender
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_execData.length > 3);
-    automationVault.addRelayEnabledCallersForTest(relay, _ALL);
-
-    for (uint256 _i; _i < _execData.length; ++_i) {
-      vm.expectCall(_execData[_i].job, _execData[_i].jobData, 1);
-    }
-
-    automationVault.exec(_sender, _execData, _feeData);
-  }
-
-  /**
-   * @notice Emit JobExecuted event when the job is executed
-   */
-  function testEmitJobExecuted(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_execData.length > 3);
-
-    for (uint256 _i; _i < _execData.length; ++_i) {
-      vm.expectEmit();
-      emit JobExecuted(relay, relayCaller, _execData[_i].job, _execData[_i].jobData);
-    }
-
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
-
-  /**
-   * @notice Checks that the test has to revert if the native token transfer failed
-   */
-  function testRevertIfNativeTokenTransferFailed(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_feeData.length > 3);
-    _feeData[1].feeToken = _ETH;
-    vm.etch(_feeData[1].feeRecipient, type(NoFallbackForTest).runtimeCode);
-
-    vm.expectRevert(IAutomationVault.AutomationVault_NativeTokenTransferFailed.selector);
-
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
-
-  /**
-   * @notice Checks that native token transfer is executed correctly
-   */
-  function testCallNativeTokenTransfer(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData,
-    uint128 _fee
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_feeData.length > 3);
-    for (uint256 _i; _i < _feeData.length; ++_i) {
-      _feeData[_i].feeToken = _ETH;
-      _feeData[_i].fee = _fee;
-    }
-
-    automationVault.exec(relayCaller, _execData, _feeData);
-
-    for (uint256 _i; _i < _feeData.length; ++_i) {
-      assertGe(_feeData[_i].feeRecipient.balance, _feeData[_i].fee);
-    }
-  }
-
-  /**
-   * @notice Checks that token transfer is executed correctly
-   */
-  function testCallTokenTransfer(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_feeData.length > 3);
-    for (uint256 _i; _i < _feeData.length; ++_i) {
-      vm.assume(_feeData[_i].feeToken != _ETH);
-    }
-
-    for (uint256 _i; _i < _feeData.length; ++_i) {
-      vm.expectCall(
-        _feeData[_i].feeToken, abi.encodeCall(IERC20.transfer, (_feeData[_i].feeRecipient, _feeData[_i].fee)), 1
-      );
-    }
-
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
-
-  /**
-   * @notice Emit IssuePayment event when the payment is issued
-   */
-  function testEmitIssuePayment(
-    IAutomationVault.ExecData[] memory _execData,
-    IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_execData, _feeData) {
-    vm.assume(_feeData.length > 3);
-
-    for (uint256 _i; _i < _feeData.length; ++_i) {
-      vm.expectEmit();
-      emit IssuePayment(relay, relayCaller, _feeData[_i].feeRecipient, _feeData[_i].feeToken, _feeData[_i].fee);
-    }
-
-    automationVault.exec(relayCaller, _execData, _feeData);
-  }
-}
+//     automationVault.exec(relayCaller, _execData, _feeData);
+//   }

--- a/solidity/test/unit/AutomationVault.t.sol
+++ b/solidity/test/unit/AutomationVault.t.sol
@@ -128,7 +128,7 @@ abstract contract AutomationVaultUnitTest is Test {
    * @param _job The job address
    * @param _selectors The function selectors
    */
-  function _createAssumes(
+  function _assumeRelayData(
     address _relay,
     address[] memory _callers,
     address _job,
@@ -159,7 +159,7 @@ contract UnitGetRelayData is AutomationVaultUnitTest {
   EnumerableSet.Bytes32Set internal _cleanSelectors;
 
   modifier happyPath(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) {
-    _createAssumes(_relay, _callers, _job, _selectors);
+    _assumeRelayData(_relay, _callers, _job, _selectors);
 
     // Clean the array to avoid duplicates
     for (uint256 _i; _i < _callers.length; ++_i) {
@@ -393,7 +393,7 @@ contract UnitAutomationVaultAddRelayData is AutomationVaultUnitTest {
 
   modifier happyPath(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) {
     /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
-    _createAssumes(_relay, _callers, _job, _selectors);
+    _assumeRelayData(_relay, _callers, _job, _selectors);
 
     // Clean the array to avoid duplicates
     for (uint256 _i; _i < _callers.length; ++_i) {
@@ -485,8 +485,7 @@ contract UnitAutomationVaultAddRelayData is AutomationVaultUnitTest {
     address _secondJob,
     bytes4[] memory _secondSelectors
   ) public {
-    _createAssumes(_relay, _callers, _job, _selectors);
-    vm.assume(_job != address(0));
+    _assumeRelayData(_relay, _callers, _job, _selectors);
     vm.assume(_secondJob != address(0));
     vm.assume(_job != _secondJob);
 
@@ -511,7 +510,7 @@ contract UnitAutomationVaultAddRelayData is AutomationVaultUnitTest {
 contract UnitAutomationVaultDeleteRelay is AutomationVaultUnitTest {
   modifier happyPath(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) {
     /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
-    _createAssumes(_relay, _callers, _job, _selectors);
+    _assumeRelayData(_relay, _callers, _job, _selectors);
 
     automationVault.addRelayForTest(_relay, _callers, _job, _selectors);
 
@@ -582,7 +581,7 @@ contract UnitAutomationVaultModifyRelay is AutomationVaultUnitTest {
 
   modifier happyPath(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) {
     /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
-    _createAssumes(_relay, _callers, _job, _selectors);
+    _assumeRelayData(_relay, _callers, _job, _selectors);
 
     // Clean the array to avoid duplicates
     for (uint256 _i; _i < _callers.length; ++_i) {
@@ -722,7 +721,7 @@ contract UnitAutomationVaultModifyRelay is AutomationVaultUnitTest {
     address _secondJob,
     bytes4[] memory _secondSelectors
   ) public {
-    _createAssumes(_relay, _callers, _job, _selectors);
+    _assumeRelayData(_relay, _callers, _job, _selectors);
     vm.assume(_job != address(0));
     vm.assume(_secondJob != address(0));
     vm.assume(_job != _secondJob);
@@ -752,7 +751,7 @@ contract UnitAutomationVaultModifyRelayCallers is AutomationVaultUnitTest {
 
   modifier happyPath(address _relay, address[] memory _callers) {
     /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
-    _createAssumes(_relay, _callers, makeAddr('job'), new bytes4[](1));
+    _assumeRelayData(_relay, _callers, makeAddr('job'), new bytes4[](1));
 
     automationVault.addRelayForTest(_relay, new address[](0), address(0), new bytes4[](0));
 
@@ -824,7 +823,7 @@ contract UnitAutomationVaultModifyRelayJobs is AutomationVaultUnitTest {
 
   modifier happyPath(address _relay, address _job, bytes4[] memory _selectors) {
     /// @dev This is a workaround for the fact that the VM does not support dynamic arrays
-    _createAssumes(_relay, new address[](1), _job, _selectors);
+    _assumeRelayData(_relay, new address[](1), _job, _selectors);
 
     automationVault.addRelayForTest(_relay, new address[](0), address(0), new bytes4[](1));
 
@@ -917,7 +916,7 @@ contract UnitAutomationVaultModifyRelayJobs is AutomationVaultUnitTest {
     address _secondJob,
     bytes4[] memory _secondSelectors
   ) public {
-    _createAssumes(_relay, _callers, _job, _selectors);
+    _assumeRelayData(_relay, _callers, _job, _selectors);
     vm.assume(_job != address(0));
     vm.assume(_secondJob != address(0));
     vm.assume(_job != _secondJob);

--- a/solidity/test/unit/AutomationVault.t.sol
+++ b/solidity/test/unit/AutomationVault.t.sol
@@ -17,24 +17,24 @@ contract AutomationVaultForTest is AutomationVault {
   }
 
   function addRelayCallerForTest(address _relay, address _caller) public {
-    _relayCallers[_relay].add(_caller);
+    _approvedCallers[_relay].add(_caller);
   }
 
   function addJobSelectorForTest(address _relay, address _job, bytes4 _selector) public {
-    _relayJobs[_relay].add(_job);
-    _jobSelectors[_job].add(bytes32(_selector));
+    _approvedJobs[_relay].add(_job);
+    _approvedJobSelectors[_relay][_job].add(bytes32(_selector));
   }
 
   function addRelayForTest(address _relay, address[] memory _callers, address _job, bytes4[] memory _selectors) public {
     for (uint256 _i; _i < _callers.length; ++_i) {
-      _relayCallers[_relay].add(_callers[_i]);
+      _approvedCallers[_relay].add(_callers[_i]);
     }
 
     if (_job != address(0)) {
-      _relayJobs[_relay].add(_job);
+      _approvedJobs[_relay].add(_job);
 
       for (uint256 _i; _i < _selectors.length; ++_i) {
-        _jobSelectors[_job].add(_selectors[_i]);
+        _approvedJobSelectors[_relay][_job].add(_selectors[_i]);
       }
     }
 
@@ -47,10 +47,10 @@ contract AutomationVaultForTest is AutomationVault {
     returns (address[] memory _callers, IAutomationVault.JobData[] memory _jobsData)
   {
     // Get the list of callers
-    _callers = _relayCallers[_relay].values();
+    _callers = _approvedCallers[_relay].values();
 
     // Get the list of all jobs
-    address[] memory _jobs = _relayJobs[_relay].values();
+    address[] memory _jobs = _approvedJobs[_relay].values();
 
     // Create the array of jobs data with the jobs length
     _jobsData = new IAutomationVault.JobData[](_jobs.length);
@@ -58,14 +58,14 @@ contract AutomationVaultForTest is AutomationVault {
     // Get the list of jobs and their selectors
     for (uint256 _i; _i < _jobs.length;) {
       // Create the array of selectors
-      bytes4[] memory _selectors = new bytes4[](_jobSelectors[_jobs[_i]].length());
+      bytes4[] memory _selectors = new bytes4[](_approvedJobSelectors[_relay][_jobs[_i]].length());
 
       // If the job has selectors, get them
       if (_selectors.length != 0) {
         // Get the list of selectors
         for (uint256 _j; _j < _selectors.length;) {
           // Convert the bytes32 selector to bytes4
-          _selectors[_j] = bytes4(_jobSelectors[_jobs[_i]].at(_j));
+          _selectors[_j] = bytes4(_approvedJobSelectors[_relay][_jobs[_i]].at(_j));
 
           unchecked {
             ++_j;

--- a/solidity/test/unit/AutomationVault.t.sol
+++ b/solidity/test/unit/AutomationVault.t.sol
@@ -994,13 +994,11 @@ contract UnitAutomationVaultExec is AutomationVaultUnitTest {
     address _caller,
     IAutomationVault.ExecData[] memory _execData,
     IAutomationVault.FeeData[] memory _feeData
-  ) public happyPath(_relay, _caller, new IAutomationVault.ExecData[](4), _feeData) {
-    IAutomationVault.ExecData[] memory _execDataNotApproved = new IAutomationVault.ExecData[](1);
-    _execDataNotApproved[0].job = _execData[0].job;
-    _execDataNotApproved[0].jobData = '0xdead';
+  ) public happyPath(_relay, _caller, _execData, _feeData) {
+    _execData[0].jobData = '0xdead';
 
     vm.expectRevert(IAutomationVault.AutomationVault_NotApprovedJobSelector.selector);
-    automationVault.exec(_caller, _execDataNotApproved, new IAutomationVault.FeeData[](0));
+    automationVault.exec(_caller, _execData, _feeData);
   }
 
   /**


### PR DESCRIPTION
New requirements are needed in order to improve xKeeper.

Added more function to manage relay

Simplify how the data are stored 

New functions follow this schema

```
- addRelay({
    callers: address[],
    jobs: Job[]
)
- deleteRelay(
    relay: address
)
- modifyRelay(
    relay: address,
    callers: address[],
    jobs: Job[]
)
- modifyRelayCallers(
    relay: address,
    callers: address[]
)
- modifyRelayJobs(
    relay: address,
    jobs: Job[]
)
```

Note: modifyRelay would just call modifyRelayCallers and modifyRelayJobs